### PR TITLE
feat: Add support for python3.8 & django4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
      python: 3.8
    - env: TOXENV=py38-3.2
      python: 3.8
-   - env: TOXENV=py38-4.0
-     python: 3.8
    - env: TOXENV=py38-4.1
      python: 3.8
    - env: TOXENV=py38-4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,37 +5,20 @@ sudo: false
 matrix:
   include:
    - env: TOXENV=flake8
-     python: 2.7
+     python: 3.8
    - env: TOXENV=isort
-     python: 2.7
+     python: 3.8
    - env: TOXENV=readme
-     python: 2.7
-   - env: TOXENV=py27-1.9
-     python: 2.7
-   - env: TOXENV=py27-1.10
-     python: 2.7
-   - env: TOXENV=py27-1.11
-     python: 2.7
-   - env: TOXENV=py34-1.9
-     python: 3.4
-   - env: TOXENV=py34-1.10
-     python: 3.4
-   - env: TOXENV=py35-1.9
-     python: 3.5
-   - env: TOXENV=py35-1.10
-     python: 3.5
-   - env: TOXENV=py35-1.11
-     python: 3.5
-   - env: TOXENV=py35-master
-     python: 3.5
-   - env: TOXENV=py36-1.9
-     python: 3.6
-   - env: TOXENV=py36-1.10
-     python: 3.6
-   - env: TOXENV=py36-1.11
-     python: 3.6
-   - env: TOXENV=py36-master
-     python: 3.6
+     python: 3.8
+   - env: TOXENV=py38-3.2
+     python: 3.8
+   - env: TOXENV=py38-4.0
+     python: 3.8
+   - env: TOXENV=py38-4.1
+     python: 3.8
+   - env: TOXENV=py38-4.2
+     python: 3.8
+
 install: pip install tox codecov
 
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-storage-swift',
-    version='1.3.0',
+    version='1.2.19',
     description='OpenStack Swift storage backend for Django',
     long_description=open('README.rst').read(),
     url='https://github.com/dennisv/django-storage-swift',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-storage-swift',
-    version='1.2.19',
+    version='1.3.0',
     description='OpenStack Swift storage backend for Django',
     long_description=open('README.rst').read(),
     url='https://github.com/dennisv/django-storage-swift',
@@ -23,12 +23,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development',
         'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/swift/storage.py
+++ b/swift/storage.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from functools import wraps
 from io import BytesIO, UnsupportedOperation
 from time import time
+
 import magic
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import sys
+
+if __name__ == "__main__":
+    sys.path.append('..')
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from django.test import TestCase
 from django.core.exceptions import ImproperlyConfigured, SuspiciousFileOperation
 from django.core.files.base import ContentFile
-from hashlib import sha1
+from hashlib import sha256
 from mock import patch
 from .utils import FakeSwift, auth_params, base_url, CONTAINER_CONTENTS, TENANT_ID
 from swift import storage
@@ -418,7 +418,7 @@ class TemporaryUrlTest(SwiftStorageTestCase):
         url_parsed = urlparse.urlsplit(url)
         params = urlparse.parse_qs(url_parsed.query)
         msg = "{}\n{}\n{}".format("GET", params['temp_url_expires'][0], urlparse.unquote(url_parsed.path))
-        sig = hmac.new(backend.temp_url_key, msg.encode('utf-8'), sha1).hexdigest()
+        sig = hmac.new(backend.temp_url_key, msg.encode('utf-8'), sha256).hexdigest()
         self.assertEqual(params['temp_url_sig'][0], sig)
 
     def test_signature(self):

--- a/tox.ini
+++ b/tox.ini
@@ -5,45 +5,43 @@ envlist =
     flake8,
     isort,
     readme,
-    py27-{1.9,1.10}
-    py34-{1.9,1.10}
-    py35-{1.9,1.10,master}
-    py36-{1.9,1.10,master}
+    py38-{3.2,4.0,4.1,4.2}
 
 [testenv]
 usedevelop = true
 basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
+    py38: python3.8
+
 deps =
     coverage
     mock>=2.0.0
-    1.9: Django>=1.9,<1.10
-    1.10: Django>=1.10,<1.11
-    1.11: Django>=1.11,<2.0
+    3.2: Django>=3.2,<3.3
+    4.0: Django>=4.0,<4.1
+    4.1: Django>=4.1,<4.2
+    4.2: Django>=4.2,<4.3
     master: https://github.com/django/django/archive/master.tar.gz
 setenv =
+    DJANGO_SETTINGS_MODULE=settings
+allowlist_externals =
+    cd
 commands =
-    {envpython} -R -Wonce {envbindir}/coverage run {envbindir}/django-admin.py test -v2 {posargs} --settings tests.settings
+    cd tests && {envpython} -R -Wonce {envbindir}/coverage run manage.py test -v2 {posargs}
     coverage report
-
 [testenv:flake8]
 usedevelop = false
-basepython = python2.7
+basepython = python3.8
 commands = flake8
 deps = flake8
 
 [testenv:isort]
 usedevelop = false
-basepython = python2.7
-commands = isort --recursive --check-only --diff swift tests
-deps = isort==4.2.5
+basepython = python3.8
+commands = isort --check-only --diff swift tests
+deps = isort==5.12.0
 
 [testenv:readme]
 usedevelop = false
-basepython = python2.7
+basepython = python3.8
 commands = python setup.py check -r -s
 deps = readme_renderer
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     flake8,
     isort,
     readme,
-    py38-{3.2,4.0,4.1,4.2}
+    py38-{3.2,4.1,4.2}
 
 [testenv]
 usedevelop = true
@@ -16,7 +16,6 @@ deps =
     coverage
     mock>=2.0.0
     3.2: Django>=3.2,<3.3
-    4.0: Django>=4.0,<4.1
     4.1: Django>=4.1,<4.2
     4.2: Django>=4.2,<4.3
     master: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
- Add Support for Python 3.8
- Add Support for Django 3.2 4.0 4.1 4.2
- Drop Support for Python < 3.8
- Drop Support for Django < 3.2

Tox output:
```
❯ tox
flake8: commands[0] tests> flake8
flake8: OK ✔ in 0.86 seconds
isort: commands[0] tests> isort --check-only --diff swift tests
Skipped 6 files
isort: OK ✔ in 0.19 seconds
readme: commands[0] tests> python setup.py check -r -s
running check
readme: OK ✔ in 0.37 seconds
py38-3.2: commands[0] tests> cd tests '&&' /Users/irtazaakram/bom/django-storage-swift/.tox/py38-3.2/bin/python -R -Wonce /Users/irtazaakram/bom/django-storage-swift/.tox/py38-3.2/bin/coverage run manage.py test -v2
py38-3.2: commands[1] tests> coverage report
Name                Stmts   Miss  Cover
---------------------------------------
swift/__init__.py       0      0   100%
swift/storage.py      274    274     0%
---------------------------------------
TOTAL                 274    274     0%
py38-3.2: OK ✔ in 0.2 seconds
py38-4.0: commands[0] tests> cd tests '&&' /Users/irtazaakram/bom/django-storage-swift/.tox/py38-4.0/bin/python -R -Wonce /Users/irtazaakram/bom/django-storage-swift/.tox/py38-4.0/bin/coverage run manage.py test -v2
py38-4.0: commands[1] tests> coverage report
Name                Stmts   Miss  Cover
---------------------------------------
swift/__init__.py       0      0   100%
swift/storage.py      274    274     0%
---------------------------------------
TOTAL                 274    274     0%
py38-4.0: OK ✔ in 0.21 seconds
py38-4.1: commands[0] tests> cd tests '&&' /Users/irtazaakram/bom/django-storage-swift/.tox/py38-4.1/bin/python -R -Wonce /Users/irtazaakram/bom/django-storage-swift/.tox/py38-4.1/bin/coverage run manage.py test -v2
py38-4.1: commands[1] tests> coverage report
Name                Stmts   Miss  Cover
---------------------------------------
swift/__init__.py       0      0   100%
swift/storage.py      274    274     0%
---------------------------------------
TOTAL                 274    274     0%
py38-4.1: OK ✔ in 0.21 seconds
py38-4.2: commands[0] tests> cd tests '&&' /Users/irtazaakram/bom/django-storage-swift/.tox/py38-4.2/bin/python -R -Wonce /Users/irtazaakram/bom/django-storage-swift/.tox/py38-4.2/bin/coverage run manage.py test -v2
py38-4.2: commands[1] tests> coverage report
Name                Stmts   Miss  Cover
---------------------------------------
swift/__init__.py       0      0   100%
swift/storage.py      274    274     0%
---------------------------------------
TOTAL                 274    274     0%
  flake8: OK (0.86=setup[0.09]+cmd[0.78] seconds)
  isort: OK (0.19=setup[0.01]+cmd[0.17] seconds)
  readme: OK (0.37=setup[0.01]+cmd[0.36] seconds)
  py38-3.2: OK (0.20=setup[0.02]+cmd[0.02,0.16] seconds)
  py38-4.0: OK (0.21=setup[0.02]+cmd[0.02,0.17] seconds)
  py38-4.1: OK (0.21=setup[0.02]+cmd[0.02,0.17] seconds)
  py38-4.2: OK (0.24=setup[0.03]+cmd[0.04,0.18] seconds)
  congratulations :) (2.46 seconds)
```